### PR TITLE
Allow for querying using before and after

### DIFF
--- a/src/Strava.php
+++ b/src/Strava.php
@@ -107,9 +107,18 @@ class Strava
     #
     # Strava User Activities
     #
-    public function activities($token, $perPage = 10)
+    public function activities($token, $perPage = 10, $after = null, $before = null)
     {
         $url = $this->strava_uri . '/athlete/activities?per_page=' . $perPage;
+
+        if ($after !== null) {
+            $url .= '&after=' . $after;
+        }
+
+        if ($before !== null) {
+            $url .= '&before=' . $before;
+        }
+
         $config = $this->bearer($token);
         $res = $this->get($url, $config);
         return $res;


### PR DESCRIPTION
Adds the ability to query via `after` & `before`, e.g 
`Strava::activities($user->access_token, 10, '1554076800', '1556668799')`

https://developers.strava.com/docs/reference/#api-Activities-getLoggedInAthleteActivities