### PR TITLE
Laravel 7 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "guzzlehttp/guzzle": "^6.3",
-        "illuminate/support": "^6.12"
+        "illuminate/support": "^7.3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Fixes #7 by bumping `illuminate/support` to minimum version for next major release.