### PR TITLE
Fix merged config key

### DIFF
--- a/src/StravaServiceProvider.php
+++ b/src/StravaServiceProvider.php
@@ -20,7 +20,7 @@ class StravaServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->mergeConfigFrom(
-          __DIR__ . '/config/strava.php', 'strava'
+          __DIR__ . '/config/strava.php', 'ct_strava'
         );
 
         $this->publishes([


### PR DESCRIPTION
Similar to @BramG's fix in #13, but changing the merged config key to `ct_strava` so that it matches everywhere.

I'm also using Laravel 7, without creating the `config/ct_strava.php` file, just setting config variables using the `.env` file. Without this fix, config is loaded into the `strava` key.