### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,13 +170,15 @@ Access tokens will now expire after 6 hours under the new flow that Strava have 
 When calling any of the Strava methods below you may want to compare the current time against the `expires_at` field in order to validate the token. If the token is expired you'll need to call the `Strava::refreshToken($refreshToken)` method in order to generate a new tokens. All you need to do is pass the users currently stored `refresh_token`, the method will then return a new set of tokens (access & refresh), update the current users tokens with the new tokens from the response. Heres an example of how that might work, using the `Strava::athlete($token)` method.
 
 ```php
+use Carbon\Carbon;
+
 public function myControllerFunction(Request $request)
 {
   // Get the user
   $user = User::find($request->id);
 
   // Check if current token has expired
-  if(Carbon::now() > $user->expires_at)
+  if(strtotime(Carbon::now()) > $user->expires_at)
   {
     // Token has expired, generate new tokens using the currently stored user refresh token
     $refresh = Strava::refreshToken($user->refresh_token);


### PR DESCRIPTION
The expires_at attribute from Strava is a timestamp, so the comparation has to be between timestamps (Carbon::now() and $user).
Also just added use "Carbon\Carbon;" for easily copy/paste.