### PR TITLE
Solve dependency conflict with Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A laravel package to access data from the Strava API.",
     "type": "library",
     "require": {
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^6.3|^7.0.1",
         "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0"
     },
     "autoload": {


### PR DESCRIPTION
Hi,

First of all a big thank you for this awesome package! 

As per [The Laravel upgrade guide](https://laravel.com/docs/8.x/upgrade#updating-dependencies), the required version of `guzzlehttp/guzzle` is 7.0.1 or higher. The current `composer.json` file requires 6.3 or higher, thus creating a conflict when updating from Laravel 7 to Laravel 8. This pull request will solve that problem. 

The package appears to working with Guzzle 7.0.1 in my Laravel app. A fair warning though: as yet, in my own Laravel application, I only authenticate and import workouts from Strava, both of which work well. Other API calls are untested.

Kind regards,
Joachim
