### PR TITLE
Getting API limits from response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ Strava::getApiUsageLimits();
 ## Parameter Types
 
 ```php
-$token        = String
+$token        = string
 $activityID   = integer
 $athleteID    = integer
 $clubID       = integer
@@ -478,7 +478,7 @@ It's highly recommended that you cache your requests made to Strava for 2 reason
 
 #### (1) Rate Limiting
 
-Strava have quite a good API Rate Limit, 600 requests every 15 minutes, 30,000 daily. If your website has high traffic you might want to consider caching your Strava response data so you don't exceed these limits.
+Strava have API Rate Limit of 100 requests every 15 minutes and 10,000 daily. If your website has high traffic you might want to consider caching your Strava response data so you don't exceed these limits.
 
 #### (2) Website Loading Speed
 

--- a/README.md
+++ b/README.md
@@ -396,6 +396,65 @@ List of the authenticated athlete's starred segments.
 Strava::starredSegments($token, $page, $perPage);
 ```
 
+## Getting API Limits 
+  
+Strava returns information about API calls allowance and usage in response headers.
+
+The methods listed below will return  this information upon a call which uses up the API limit (like fetching activities). Some calls like refreshing access tokens seem not to use up the API call limit, that's why you will get nulls in the resulting array.
+
+As well when you try to get the limits at the very beginning, before any API call using up the limits , you will receive nulls. The default allowance limits are not hardcoded as different accounts may have different limits.
+  
+## Getting API Limits 
+  
+Strava returns information about API calls allowance and usage in response headers.
+
+The methods listed below will return  this information upon a call which uses up the API limit (like fetching activities). Some calls like refreshing access tokens seem not to use up the API call limit, that's why you will get nulls in the resulting array.
+
+As well when you try to get the limits at the very beginning, before any API call using up the limits , you will receive nulls. The default allowance limits are not hardcoded as different accounts may have different limits.
+  
+#### All API Limits 
+Returns all limits in a multidimensional array, eg.:
+
+```php  
+[  
+	['allowance']['15minutes'] => "100",  
+	['allowance']['daily'] => "1000",  
+	['usage']['15minutes'] => "7",  
+	['usage']['daily'] => "352",  
+]
+```  
+  
+```php  
+Strava::getApiLimits();
+```  
+#### Allocated API Limits 
+Returns daily and 15-minute request limits available for the Strava account , eg.:
+
+```php  
+[  
+	['15minutes'] => '100',  
+	['daily'] => '1000',  
+]
+```  
+  
+```php  
+Strava::getApiAllowanceLimits();
+```  
+
+#### Used API Calls
+Returns number of daily and 15-minute calls used up at the Strava account , eg.:
+
+```php  
+[  
+	['15minutes'] => '7',  
+	['daily'] => '352',  
+]
+```  
+  
+```php  
+Strava::getApiUsageLimits();
+```  
+
 
 ## Parameter Types
 

--- a/src/Strava.php
+++ b/src/Strava.php
@@ -34,7 +34,7 @@ class Strava
     #
     public function authenticate($scope='read_all,profile:read_all,activity:read_all')
     {
-      return redirect('https://www.strava.com/oauth/authorize?client_id='. $this->client_id .'&response_type=code&redirect_uri='. $this->redirect_uri . '&scope=' . $scope . '&state=strava');
+        return redirect('https://www.strava.com/oauth/authorize?client_id='. $this->client_id .'&response_type=code&redirect_uri='. $this->redirect_uri . '&scope=' . $scope . '&state=strava');
     }
 
 
@@ -43,14 +43,14 @@ class Strava
     #
     public function unauthenticate($token)
     {
-      $url = 'https://www.strava.com/oauth/deauthorize';
-      $config = [
-          'form_params' => [
-              'access_token' => $token
-          ]
-      ];
-      $res = $this->post($url, $config);
-      return $res;
+        $url = 'https://www.strava.com/oauth/deauthorize';
+        $config = [
+            'form_params' => [
+                'access_token' => $token
+            ]
+        ];
+        $res = $this->post($url, $config);
+        return $res;
     }
 
 
@@ -61,12 +61,12 @@ class Strava
     {
         $url = 'https://www.strava.com/oauth/token';
         $config = [
-          'form_params' => [
-              'client_id' => $this->client_id,
-              'client_secret' => $this->client_secret,
-              'code' => $code,
-              'grant_type' => 'authorization_code'
-          ]
+            'form_params' => [
+                'client_id' => $this->client_id,
+                'client_secret' => $this->client_secret,
+                'code' => $code,
+                'grant_type' => 'authorization_code'
+            ]
         ];
         $res = $this->post($url, $config);
         return $res;
@@ -80,12 +80,12 @@ class Strava
     {
         $url = 'https://www.strava.com/oauth/token';
         $config = [
-          'form_params' => [
-              'client_id' => $this->client_id,
-              'client_secret' => $this->client_secret,
-              'refresh_token' => $refreshToken,
-              'grant_type' => 'refresh_token'
-          ]
+            'form_params' => [
+                'client_id' => $this->client_id,
+                'client_secret' => $this->client_secret,
+                'refresh_token' => $refreshToken,
+                'grant_type' => 'refresh_token'
+            ]
         ];
         $res = $this->post($url, $config);
         return $res;
@@ -144,7 +144,7 @@ class Strava
     {
         if ($keys != '')
             $keys = join(",", $keys);
-        
+
         $url = $this->strava_uri . '/activities/'. $activityID .'/streams?keys='. $keys .'&key_by_type'. $keyByType;
         $config = $this->bearer($token);
         $res = $this->get($url, $config);
@@ -383,12 +383,12 @@ class Strava
     #
     private function bearer($token)
     {
-      $config = [
-        'headers' => [
-            'Authorization' => 'Bearer '.$token.''
-        ],
-      ];
-      return $config;
+        $config = [
+            'headers' => [
+                'Authorization' => 'Bearer '.$token.''
+            ],
+        ];
+        return $config;
     }
 
 

--- a/src/Strava.php
+++ b/src/Strava.php
@@ -16,6 +16,10 @@ class Strava
     private $client_secret;
     private $redirect_uri;
 
+    private $api_limits = [];
+    private const HEADER_API_ALLOWANCE = 'X-RateLimit-Limit';
+    private const HEADER_API_USAGE = 'X-RateLimit-Usage';
+
 
     #
     # Constructor
@@ -362,6 +366,7 @@ class Strava
     public function post($url, $config)
     {
         $res = $this->client->post( $url, $config );
+        $this->parseApiLimits($res->getHeader(self::HEADER_API_ALLOWANCE), $res->getHeader(self::HEADER_API_USAGE));
         $result = json_decode($res->getBody()->getContents());
         return $result;
     }
@@ -373,6 +378,7 @@ class Strava
     public function get($url, $config)
     {
         $res = $this->client->get( $url, $config );
+        $this->parseApiLimits($res->getHeader(self::HEADER_API_ALLOWANCE), $res->getHeader(self::HEADER_API_USAGE));
         $result = json_decode($res->getBody()->getContents());
         return $result;
     }
@@ -392,4 +398,43 @@ class Strava
     }
 
 
+    #
+    # Return API limits
+    #
+    public function getApiLimits()
+    {
+        return $this->api_limits;
+    }
+
+    public function getApiAllowanceLimits()
+    {
+        return $this->api_limits['allowance'];
+    }
+
+    public function getApiUsageLimits()
+    {
+        return $this->api_limits['usage'];
+    }
+
+    private function parseApiLimits($allowance, $usage)
+    {
+        if (isset($allowance[0])) {
+            $allowance = explode(',', $allowance[0]);
+
+            $this->api_limits['allowance']['15minutes'] = isset($allowance[0]) ? trim($allowance[0]) : null;
+            $this->api_limits['allowance']['daily'] = isset($allowance[1]) ? trim($allowance[0]) : null;
+        } else {
+            $this->api_limits['allowance']['15minutes'] = null;
+            $this->api_limits['allowance']['daily'] = null;
+        }
+
+        if (isset($usage[0])) {
+            $usage = explode(',', $usage[0]);
+            $this->api_limits['usage']['15minutes'] = isset($usage[0]) ? trim($usage[0]) : null;
+            $this->api_limits['usage']['daily'] = isset($usage[1]) ? trim($usage[1]) : null;
+        } else {
+            $this->api_limits['usage']['15minutes'] = null;
+            $this->api_limits['usage']['daily'] = null;
+        }
+    }
 }

--- a/src/StravaServiceProvider.php
+++ b/src/StravaServiceProvider.php
@@ -20,11 +20,11 @@ class StravaServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->mergeConfigFrom(
-          __DIR__ . '/config/strava.php', 'ct_strava'
+            __DIR__ . '/config/strava.php', 'ct_strava'
         );
 
         $this->publishes([
-          __DIR__ . '/config/strava.php' => config_path('ct_strava.php')
+            __DIR__ . '/config/strava.php' => config_path('ct_strava.php')
         ]);
     }
 
@@ -39,10 +39,10 @@ class StravaServiceProvider extends ServiceProvider
             $client = new Client();
 
             return new Strava(
-              config('ct_strava.client_id'),
-              config('ct_strava.client_secret'),
-              config('ct_strava.redirect_uri'),
-              $client
+                config('ct_strava.client_id'),
+                config('ct_strava.client_secret'),
+                config('ct_strava.redirect_uri'),
+                $client
             );
 
         });

--- a/src/config/strava.php
+++ b/src/config/strava.php
@@ -6,8 +6,8 @@
 
 return [
 
-  'client_id' => env('CT_STRAVA_CLIENT_ID', ''),
-  'client_secret' => env('CT_STRAVA_SECRET_ID', ''),
-  'redirect_uri' => env('CT_STRAVA_REDIRECT_URI', ''),
+    'client_id' => env('CT_STRAVA_CLIENT_ID', ''),
+    'client_secret' => env('CT_STRAVA_SECRET_ID', ''),
+    'redirect_uri' => env('CT_STRAVA_REDIRECT_URI', ''),
 
 ];


### PR DESCRIPTION
Strava returns information about API calls allowance and usage in response headers. Let's read it and make this information available inside the class.

I updated as well the readme file with explanations on how to use the new methods.