### PR TITLE
Add updateActivityById method

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A laravel package to access data from the Strava API. Compatible with ```Laravel
   - [Activity Kudos](https://github.com/RichieMcMullen/strava#activity-kudos)
   - [Activity Laps](https://github.com/RichieMcMullen/strava#activity-laps)
   - [Activity Zones](https://github.com/RichieMcMullen/strava#activity-zones)
+  - [Update Activity](https://github.com/RichieMcMullen/strava#update-activity)
   - [Athlete Zones](https://github.com/RichieMcMullen/strava#athlete-zones)
   - [Athlete Stats](https://github.com/RichieMcMullen/strava#athlete-stats)
   - [Club](https://github.com/RichieMcMullen/strava#club)
@@ -290,6 +291,33 @@ Summit Feature Required. Returns the zones of a given activity.
 ```php
 Strava::activityZones($token, $activityID);
 ```
+
+#### Update Activity
+
+Updates the given activity that is owned by the authenticated athlete. Requires `activity:write`, so in order to update activities, you will need to authenticate as follows: `Strava::authenticate('read_all,profile:read_all,activity:read_all,activity:write');`.
+
+```php
+Strava::updateActivityById($token, $activityID, array $updateableActivity);
+```
+
+You may update one or more individual parameters from the following:
+
+```php
+// Example $updateableActivity
+$updateableActivity = [
+    'commute' => false,
+    'trainer' => false,
+    'description' => 'Easier ride than usual',
+    'name' => 'Fun ride',
+    'type' => 'Ride', // string, instance of ActivityType
+    'gear_id' => 'b12345678987654321',
+];
+```
+
+Find additional details in the official Strava documentation:
+
+- [UpdateableActivity](https://developers.strava.com/docs/reference/#api-models-UpdatableActivity)
+- [ActivityType](https://developers.strava.com/docs/reference/#api-models-ActivityType)
 
 #### Athlete Zones
 

--- a/src/Strava.php
+++ b/src/Strava.php
@@ -142,6 +142,18 @@ class Strava
 
 
     #
+    # Update Strava Single Activity
+    #
+    public function updateActivityById($token, $activityID, array $updateableActivity)
+    {
+        $url = $this->strava_uri . '/activities/'. $activityID;
+        $config = array_merge($this->bearer($token), ['form_params' => $updateableActivity]);
+        $res = $this->put($url, $config, $updateableActivity);
+        return $res;
+    }
+
+
+    #
     # Strava Single Activity Stream
     #
     public function activityStream($token, $activityID, $keys = '', $keyByType = true)
@@ -366,6 +378,18 @@ class Strava
     public function post($url, $config)
     {
         $res = $this->client->post( $url, $config );
+        $this->parseApiLimits($res->getHeader(self::HEADER_API_ALLOWANCE), $res->getHeader(self::HEADER_API_USAGE));
+        $result = json_decode($res->getBody()->getContents());
+        return $result;
+    }
+
+
+    #
+    # Strava PUT
+    #
+    public function put($url, $config)
+    {
+        $res = $this->client->put($url, $config);
         $this->parseApiLimits($res->getHeader(self::HEADER_API_ALLOWANCE), $res->getHeader(self::HEADER_API_USAGE));
         $result = json_decode($res->getBody()->getContents());
         return $result;


### PR DESCRIPTION
The purpose of this PR is to add the ability to update an Activity, by implementing the [updateActivityById](https://developers.strava.com/docs/reference/#api-Activities-updateActivityById) Strava API.

Here's a simple example of how this might be used:

```php
Strava::updateActivityById($token, $activityID, [
    'name' => 'Fun ride',
    'description' => 'Easier ride than usual',
]);
```

I have updated the README with details on how to use this new utility, including the new `activity:write` permission.

The addition of the `put()` method will allow implementation of other similar APIs, such as **updateLoggedInAthlete** and **starSegment**.

I hope you'll find this useful. I am already using it in my own app, to update activity names and descriptions from a dashboard.