### PR TITLE
Added segmentStream method to Strava class

### DIFF
--- a/src/Strava.php
+++ b/src/Strava.php
@@ -359,6 +359,21 @@ class Strava
         return $res;
     }
 
+    
+    #
+    # Strava Activity Segment Stream
+    #
+    public function segmentStream($token, $segmentID, $keys = '', $keyByType = true)
+    {
+        if ($keys != '')
+            $keys = join(",", $keys);
+
+        $url = $this->strava_uri . '/segments/'. $segmentID .'/streams?keys='. $keys .'&key_by_type'. $keyByType;
+        $config = $this->bearer($token);
+        $res = $this->get($url, $config);
+        return $res;
+    }
+
 
     #
     # Strava List Starred Segments


### PR DESCRIPTION
I've added the method to get the stream for a segment, as described in API function https://developers.strava.com/docs/reference/#api-Streams-getSegmentStreams. I've copied the existing method activityStream because this method already had the required logic.
