### PR TITLE
Fix method on single activity

### DIFF
--- a/src/Strava.php
+++ b/src/Strava.php
@@ -139,6 +139,20 @@ class Strava
         $res = $this->get($url, $config);
         return $res;
     }
+    
+    #
+    # Strava Create Activity
+    #
+    public function createActivity($token, $data = [])
+    {
+        $url = $this->strava_uri . '/activities';
+        $config = $this->bearer($token);
+        $config = array_merge($config, [
+            'form_params' => $data
+        ]);
+        $res = $this->post($url, $config);
+        return $res;
+    }
 
 
     #


### PR DESCRIPTION
This would allow users the ability to add events back to Strava if they have the correct scope on their activity token.

## Usage

```php
$activities = Strava::createActivity($token, [
    'name' => 'Testing API',
    'type' => 'Workout',
    'start_date_local' => now()->toIso8601String(),
    'elapsed_time' => 60,
    'description' => 'I passed through the seven levels of the Candy Cane forest, through the sea of swirly twirly gum drops, and then I walked through the Lincoln Tunnel.',
    'trainer' => 1,
]);
```