### PR TITLE
Define Callback URI

### DIFF
--- a/src/Strava.php
+++ b/src/Strava.php
@@ -36,9 +36,17 @@ class Strava
     #
     # Strava Authenticate
     #
-    public function authenticate($scope='read_all,profile:read_all,activity:read_all')
+    public function authenticate($scope = 'read_all,profile:read_all,activity:read_all', $redirect_uri = null)
     {
-        return redirect('https://www.strava.com/oauth/authorize?client_id='. $this->client_id .'&response_type=code&redirect_uri='. $this->redirect_uri . '&scope=' . $scope . '&state=strava');
+        $query = http_build_query([
+            'client_id' => $this->client_id,
+            'response_type' => 'code',
+            'redirect_uri' => $redirect_uri ?: $this->redirect_uri,
+            'scope' => $scope,
+            'state' => 'strava',
+        ]);
+
+        return redirect("https://www.strava.com/oauth/authorize?{$query}");
     }
 
 


### PR DESCRIPTION
Fixes #17 

Default value is still defined by the environment variable `CT_STRAVA_REDIRECT_URI`. But it can now be overriden in the function call:

```php
return Strava::authenticate($scope='read_all,profile:read_all,activity:read_all', $redirect_uri);
```