### PR TITLE
Bugfix for query string character in segmentStream

### DIFF
--- a/src/Strava.php
+++ b/src/Strava.php
@@ -390,7 +390,7 @@ class Strava
         if ($keys != '')
             $keys = join(",", $keys);
 
-        $url = $this->strava_uri . '/segments/'. $segmentID .'/streams?keys='. $keys .'&key_by_type'. $keyByType;
+        $url = $this->strava_uri . '/segments/'. $segmentID .'/streams?keys='. $keys .'&key_by_type='. $keyByType;
         $config = $this->bearer($token);
         $res = $this->get($url, $config);
         return $res;


### PR DESCRIPTION
The Strava API URL in the segmentStream method misses an equal (=) sign for the key_by_type parameter. This parameter is required according to the specs (https://developers.strava.com/docs/reference/#api-Streams-getSegmentStreams) and should always be true.